### PR TITLE
Docs in browser

### DIFF
--- a/api/lib/gateways/S3Gateway.js
+++ b/api/lib/gateways/S3Gateway.js
@@ -15,7 +15,8 @@ module.exports = function(options) {
           console.log(`Got doc id=${id} from s3`);
           return {
             doc: response.Body,
-            mimeType: response.Metadata.mimetype
+            mimeType: response.Metadata.mimetype,
+            extenstion: response.Metadata.extension
           };
         }
       } catch (err) {
@@ -30,7 +31,7 @@ module.exports = function(options) {
           ResponseContentType: mimeType
         };
         if (extension) {
-          requestParams.ResponseContentDisposition = `attachment; filename ="${id}.${extension}"`;
+          requestParams.ResponseContentDisposition = `inline; filename =${id}.${extension}`;
         }
 
         return await s3.getSignedUrl("getObject", requestParams);
@@ -46,7 +47,7 @@ module.exports = function(options) {
             Bucket: process.env.S3_BUCKET_NAME,
             Key: `${id}`,
             Body: document.doc,
-            Metadata: { mimetype: document.mimeType }
+            Metadata: { mimetype: document.mimeType, extension: document.extension }
           })
           .promise();
         if (response.data) {

--- a/api/lib/gateways/S3Gateway.js
+++ b/api/lib/gateways/S3Gateway.js
@@ -47,7 +47,10 @@ module.exports = function(options) {
             Bucket: process.env.S3_BUCKET_NAME,
             Key: `${id}`,
             Body: document.doc,
-            Metadata: { mimetype: document.mimeType, extension: document.extension }
+            Metadata: {
+              mimetype: document.mimeType,
+              extension: document.extension
+            }
           })
           .promise();
         if (response.data) {

--- a/api/lib/use-cases/GetDocument.js
+++ b/api/lib/use-cases/GetDocument.js
@@ -30,9 +30,9 @@ module.exports = function(options) {
 
       await s3Gateway.put(documentId, doc);
     }
-   
+
     doc.url = await s3Gateway.getUrl(documentId, doc.mimeType, doc.extension);
-    
+
     return doc;
   };
 };

--- a/api/lib/use-cases/GetDocument.js
+++ b/api/lib/use-cases/GetDocument.js
@@ -18,18 +18,21 @@ module.exports = function(options) {
         return null;
       }
 
-      const mimeType = mimeTypes.extension(outputDoc.headers["content-type"]);
+      const mimeType = outputDoc.headers["content-type"]
+      const extension = mimeTypes.extension(mimeType)
+
       doc = {
         mimeType,
+        extension,
         doc: outputDoc.body,
-        filename: `${documentId}.${mimeType}`
+        filename: `${documentId}.${extension}`
       };
 
       await s3Gateway.put(documentId, doc);
     }
-
-    doc.url = await s3Gateway.getUrl(documentId, doc.mimeType, doc.mimeType);
-
+   
+    doc.url = await s3Gateway.getUrl(documentId, doc.mimeType, doc.extension);
+    
     return doc;
   };
 };

--- a/api/test/use-cases/GetDocument.test.js
+++ b/api/test/use-cases/GetDocument.test.js
@@ -18,7 +18,8 @@ const createS3GatewaySpy = document => {
       if (id === 1) {
         return {
           doc: 'cached document',
-          mimeType: 'xml',
+          mimeType: 'text/xml',
+          extension: 'xml',
           url: 'www.cachedDocumentUrl.com'
         }
       }
@@ -60,7 +61,8 @@ describe('GetDocument', function() {
 
     expect(edocsGatewaySpy.getDocument).toHaveBeenCalledTimes(1);
     expect(attachment.doc).toBe(document);
-    expect(attachment.mimeType).toBe('xml')
+    expect(attachment.mimeType).toBe('text/xml')
+    expect(attachment.extension).toBe('xml')
     expect(attachment.filename).toBe('1234.xml')
   });
 


### PR DESCRIPTION
PDFs weren't opening in Chrome when other browsers were fine, so we were just downloading all files instead, which isn't ideal.

Turns out this was because we were mixing up mimetypes and extensions in the Use Case, so I guess Chrome wasn't receiving valid mimetypes for files, so it didn't open them.

I've separated the mimeType and extension and stored both as Metadata.