### PR TITLE
Update allowed group in authorizer

### DIFF
--- a/api/authorizer.js
+++ b/api/authorizer.js
@@ -49,7 +49,6 @@ function decodeToken(token) {
 
 function userInAllowedGroup(userGroups) {
   if (!(userGroups && userGroups.length !== undefined)) return false;
-  if (allowedGroups.indexOf("*") >= 0) return true;
   for (const group of userGroups) {
     if (allowedGroups.indexOf(group) >= 0) return true;
   }

--- a/serverless.yml
+++ b/serverless.yml
@@ -46,7 +46,7 @@ functions:
     handler: api/authorizer.handler
     environment:
       jwtsecret: ${ssm:/common/hackney-jwt-secret}
-      allowedGroups: '*'
+      allowedGroups: ${self:provider.stage}-edocs-web-access
 
 custom:
   stage: ${self:provider.stage}


### PR DESCRIPTION
### Context
We want to allow a certain group to be able to access the documents from edocs API:
- staging-edocs-web-access group
- production-edocs-web-access group

### Change in this PR
- Update the `serverless.yml` to use these groups 

### Trello card 
https://trello.com/c/HBCiZWqO/24-new-google-auth-group-to-be-added-for-edocs-access
