### PR TITLE
Redirect to google auth if user is unauthorised

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -7,6 +7,7 @@ const edocsGateway = require('./lib/gateways/EdocsGateway')({
   edocsServerUrl: process.env.EDOCS_API_URL,
   apiKey: process.env.EDOCS_API_KEY
 });
+const authorizer = require('./authorizer.js')
 
 var s3Gateway
 
@@ -71,6 +72,13 @@ app.get('/documents/:documentId', async (req, res) => {
 });
 
 app.get('/lbhMosaicEDocs/DocumentMenu.aspx', async (req, res) => {
+  var permission = await authorizer(req)
+
+  if(permission === 'Unauthorized') {
+    const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
+    return res.redirect(`http://auth.hackney.gov.uk/auth?redirect_uri=${fullUrl}`)
+  }
+
   const documentId = req.query.documentId
   res.redirect(`/documents/${documentId}`)
 })

--- a/serverless.yml
+++ b/serverless.yml
@@ -36,9 +36,12 @@ functions:
         - node_modules/**
     events:
       - http:
-          path: '{proxy+}'
+          path: /documents/{documentId}
           method: GET
           authorizer: ${self:custom.authorizer.edocs-documents-api-authorizer}
+      - http:
+          path: /lbhMosaicEDocs/DocumentMenu.aspx
+          method: GET
 
     environment:
       stage: ${self:provider.stage}


### PR DESCRIPTION
### Context
We want to be able to listen to the DRF URL and redirect to the new documents endpoint so that when a user is coming from outside the hackney network can view documents over the API. We also need to make sure the new endpoint has authorization. 

### Changes

- Add `authorization` to the DRF endpoint