### PR TITLE
Check if user is in allowed group

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -90,6 +90,11 @@ app.get('/lbhMosaicEDocs/DocumentMenu.aspx', async (req, res) => {
 
   var permission = await authorizer.handler(req)
 
+  if(permission === 'Not Allowed') {
+    res.status(403)
+    return res.send("You don't have permission to use this service, please contact a google admin to see if you are in the correct usergroup")
+  }
+
   if(permission === 'Unauthorized') {
     
     const fullUrl= process.env.redirectUri + req.originalUrl


### PR DESCRIPTION
### Context 

When a user is not in the `allowed group` they stuck in an infinite loop because the service redirects `unauthorized` users to google sign-in. We want to show a friendly error message when they successfully authorized but don't have the permission to use the service.

### Change
- Render the message `You don't have permission to use this service, please contact a google admin to see if you are in the correct usergroup` when a user successfully logged in but not in the allowed user groups.

### Tello card
https://trello.com/c/jdog3nkW/41-auth-error-page