### PR TITLE
Whitelist file extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ jspm_packages
 *npm-debug.log*
 *tmp
 /authorizer/event.json
-
+.dynamodb
 
 # Serverless directories
 *.serverless

--- a/api/index.js
+++ b/api/index.js
@@ -82,7 +82,7 @@ app.get('/lbhMosaicEDocs/DocumentMenu.aspx', async (req, res) => {
     
     const fullUrl= process.env.redirectUri + req.originalUrl
 
-    return res.redirect(`http://auth.hackney.gov.uk/auth?redirect_uri=${fullUrl}`)
+    return res.redirect(`${process.env.googleAuthRedirectUri}${fullUrl}`)
   }
 
   const documentId = req.query.documentId

--- a/api/index.js
+++ b/api/index.js
@@ -59,9 +59,9 @@ app.get('/documents/:documentId', async (req, res) => {
   res.set('Pragma', 'no-cache')
 
   try {
-    docUrl = await getDoc(documentId, sofficePromise)
+    doc = await getDocument(documentId, sofficePromise)
 
-    if (!docUrl) {
+    if (!doc.url) {
       res.status(404)
       res.send('Requested document does not exist')
       return
@@ -71,17 +71,16 @@ app.get('/documents/:documentId', async (req, res) => {
     if (payload && payload.name && payload.email) {
       await logDocumentAccess(documentId, payload.name, payload.email)
       res.status(301)
-      res.set('Location', docUrl)
+      res.set('Location', doc.url)
       res.send('')
     } else {
       res.status(400)
       res.send("Couldn't find name and email in request")
     }
   } catch (err) {
-    console.log(err);
-
+    console.log(err)
     res.status(500)
-    res.send(err)
+    res.send(err.toString())
   }
 
 });
@@ -105,14 +104,6 @@ app.get('/lbhMosaicEDocs/DocumentMenu.aspx', async (req, res) => {
   const documentId = req.query.documentId
   res.redirect(`/documents/${documentId}`)
 })
-
-const getDoc = async (documentId, sofficePromise) => {
-    const doc = await getDocument(documentId, sofficePromise);
-
-    if (!doc) return null
-  
-    return doc.url
-}
 
 module.exports.handler = serverless(app, {
   binary: ['*/*']

--- a/api/lib/gateways/DynamoDbGateway.js
+++ b/api/lib/gateways/DynamoDbGateway.js
@@ -8,20 +8,19 @@ module.exports = function({ client, tables }) {
     ) {
       try {
         await client
-        .put({
-          TableName: tables.accessLogsTable,
-          Item: {
-            documentId,
-            accessTime: accessTime.toISOString(),
-            userName,
-            userEmail
-          }
-        })
-        .promise();
+          .put({
+            TableName: tables.accessLogsTable,
+            Item: {
+              documentId,
+              accessTime: accessTime.toISOString(),
+              userName,
+              userEmail
+            }
+          })
+          .promise();
       } catch (err) {
-        console.log(err)
+        console.log(err);
       }
-      
     }
   };
 };

--- a/api/lib/use-cases/GetDocument.js
+++ b/api/lib/use-cases/GetDocument.js
@@ -1,6 +1,6 @@
 const mimeTypes = require("mime-types");
 const fs = require("fs");
-
+const selectFileAction = require('./SelectFileAction')
 function saveFileLocally(docBody, fileName) {
   try {
     fs.writeFileSync(`/tmp/${fileName}`, docBody);
@@ -34,7 +34,13 @@ module.exports = function(options) {
 
         var document = outputDoc.body;
 
-        if (extension === "doc" || extension === "docx") {
+        const fileAction = selectFileAction(extension)
+        
+        if (fileAction === 'unsupported') {
+          throw new Error('This document cannot be viewed in your browser, please open in Mosaic on VDI.')
+        }
+
+        if (fileAction === 'convert') {
           var fileName = saveFileLocally(
             document,
             `${documentId}.${extension}`
@@ -72,7 +78,7 @@ module.exports = function(options) {
       } catch (err) {
         console.log(`Error: couldn't find document with id: ${documentId}`);
         console.log(err);
-        return null;
+        return err;
       }
     }
 

--- a/api/lib/use-cases/GetDocument.js
+++ b/api/lib/use-cases/GetDocument.js
@@ -1,6 +1,6 @@
 const mimeTypes = require("mime-types");
 const fs = require("fs");
-const selectFileAction = require('./SelectFileAction')
+const selectFileAction = require("./SelectFileAction");
 function saveFileLocally(docBody, fileName) {
   try {
     fs.writeFileSync(`/tmp/${fileName}`, docBody);
@@ -26,7 +26,9 @@ module.exports = function(options) {
 
       try {
         outputDoc = await edocsGateway.getDocument(documentId);
-        console.log(`Document with id: ${documentId} fetched from edocs gateway`);
+        console.log(
+          `Document with id: ${documentId} fetched from edocs gateway`
+        );
       } catch (err) {
         console.log(`Document with id: ${documentId} not found in edocs`);
         throw err;
@@ -39,17 +41,16 @@ module.exports = function(options) {
 
       var document = outputDoc.body;
 
-      const fileAction = selectFileAction(extension)
-      
-      if (fileAction === 'unsupported') {
-        throw new Error('This document cannot be viewed in your browser, please open in Mosaic on VDI.')
+      const fileAction = selectFileAction(extension);
+
+      if (fileAction === "unsupported") {
+        throw new Error(
+          "This document cannot be viewed in your browser, please open in Mosaic on VDI."
+        );
       }
 
-      if (fileAction === 'convert') {
-        var fileName = saveFileLocally(
-          document,
-          `${documentId}.${extension}`
-        );
+      if (fileAction === "convert") {
+        var fileName = saveFileLocally(document, `${documentId}.${extension}`);
 
         try {
           fileName = await convertDocument.execute(fileName, sofficePromise);

--- a/api/lib/use-cases/GetDocument.js
+++ b/api/lib/use-cases/GetDocument.js
@@ -78,7 +78,7 @@ module.exports = function(options) {
       } catch (err) {
         console.log(`Error: couldn't find document with id: ${documentId}`);
         console.log(err);
-        return err;
+        throw err;
       }
     }
 

--- a/api/lib/use-cases/GetDocument.js
+++ b/api/lib/use-cases/GetDocument.js
@@ -22,64 +22,64 @@ module.exports = function(options) {
     let doc = await s3Gateway.get(documentId);
 
     if (!doc) {
+      var outputDoc;
+
       try {
-        const outputDoc = await edocsGateway.getDocument(documentId);
-
-        if (outputDoc.statusCode != 200) return null;
-
-        var mimeType = outputDoc.headers["content-type"];
-        var extension = mimeTypes.extension(mimeType);
-
-        console.log("From edocs retrieved:", `${documentId}.${extension}`);
-
-        var document = outputDoc.body;
-
-        const fileAction = selectFileAction(extension)
-        
-        if (fileAction === 'unsupported') {
-          throw new Error('This document cannot be viewed in your browser, please open in Mosaic on VDI.')
-        }
-
-        if (fileAction === 'convert') {
-          var fileName = saveFileLocally(
-            document,
-            `${documentId}.${extension}`
-          );
-
-          try {
-            fileName = await convertDocument.execute(fileName, sofficePromise);
-            console.log("File converted successfully");
-          } catch (err) {
-            console.log(err);
-            console.log("File not converted");
-            throw err;
-          }
-
-          extension = fileName.split(".").pop();
-
-          try {
-            document = fs.readFileSync(`/tmp/${fileName}`);
-
-            mimeType = "application/pdf";
-          } catch (err) {
-            console.log(err);
-            console.log("File not read");
-            throw err;
-          }
-        }
-        doc = {
-          mimeType,
-          extension,
-          doc: document,
-          filename: `${documentId}.${extension}`
-        };
-
-        await s3Gateway.put(documentId, doc);
+        outputDoc = await edocsGateway.getDocument(documentId);
+        console.log(`Document with id: ${documentId} fetched from edocs gateway`);
       } catch (err) {
-        console.log(`Error: couldn't find document with id: ${documentId}`);
-        console.log(err);
+        console.log(`Document with id: ${documentId} not found in edocs`);
         throw err;
       }
+
+      if (outputDoc.statusCode != 200) return null;
+
+      var mimeType = outputDoc.headers["content-type"];
+      var extension = mimeTypes.extension(mimeType);
+
+      var document = outputDoc.body;
+
+      const fileAction = selectFileAction(extension)
+      
+      if (fileAction === 'unsupported') {
+        throw new Error('This document cannot be viewed in your browser, please open in Mosaic on VDI.')
+      }
+
+      if (fileAction === 'convert') {
+        var fileName = saveFileLocally(
+          document,
+          `${documentId}.${extension}`
+        );
+
+        try {
+          fileName = await convertDocument.execute(fileName, sofficePromise);
+          console.log("File converted successfully");
+        } catch (err) {
+          console.log(err);
+          console.log("File not converted");
+          throw err;
+        }
+
+        extension = fileName.split(".").pop();
+
+        try {
+          document = fs.readFileSync(`/tmp/${fileName}`);
+
+          mimeType = "application/pdf";
+        } catch (err) {
+          console.log(err);
+          console.log("File not read");
+          throw err;
+        }
+      }
+      doc = {
+        mimeType,
+        extension,
+        doc: document,
+        filename: `${documentId}.${extension}`
+      };
+
+      await s3Gateway.put(documentId, doc);
     }
 
     doc.url = await s3Gateway.getUrl(documentId, doc.mimeType, doc.extension);

--- a/api/lib/use-cases/SelectFileAction.js
+++ b/api/lib/use-cases/SelectFileAction.js
@@ -1,0 +1,17 @@
+module.exports = function(fileExtension) {
+  const responses = {
+    UNSUPPORTED: 'unsupported',
+    CONVERT: 'convert',
+    WEBNATIVE: 'web native'
+  }
+  const libreOfficeSupportedFileExtensions = ['doc', 'docx', 'ppt' , 'pptx' , 'xls' , 'xlsx' , 'numbers' , 'pages' , 'key' , 'csv' , 'txt', 'odt' , 'ods' , 'odt' , 'odp' , 'rtf' , 'xlt' , 'psd', 'cdr' , 'eps' , 'psw' , 'dot' , 'tiff']
+  
+  const webNativeFileExtensions = ['pdf', 'apng', 'bmp', 'gif', 'ico', 'cur', 'jpg', 'jpeg', 'jfif', 'pjpeg', 'pjp', 'png', 'svg', 'xml']
+  
+  if (libreOfficeSupportedFileExtensions.includes(fileExtension)) {
+    return responses.CONVERT
+  } else if (webNativeFileExtensions.includes(fileExtension)) {
+    return responses.WEBNATIVE
+  }
+  return responses.UNSUPPORTED
+}

--- a/api/lib/use-cases/SelectFileAction.js
+++ b/api/lib/use-cases/SelectFileAction.js
@@ -1,17 +1,56 @@
 module.exports = function(fileExtension) {
   const responses = {
-    UNSUPPORTED: 'unsupported',
-    CONVERT: 'convert',
-    WEBNATIVE: 'web native'
-  }
-  const libreOfficeSupportedFileExtensions = ['doc', 'docx', 'ppt' , 'pptx' , 'xls' , 'xlsx' , 'numbers' , 'pages' , 'key' , 'csv' , 'txt', 'odt' , 'ods' , 'odt' , 'odp' , 'rtf' , 'xlt' , 'psd', 'cdr' , 'eps' , 'psw' , 'dot' , 'tiff']
-  
-  const webNativeFileExtensions = ['pdf', 'apng', 'bmp', 'gif', 'ico', 'cur', 'jpg', 'jpeg', 'jfif', 'pjpeg', 'pjp', 'png', 'svg', 'xml']
-  
+    UNSUPPORTED: "unsupported",
+    CONVERT: "convert",
+    WEBNATIVE: "web native"
+  };
+  const libreOfficeSupportedFileExtensions = [
+    "doc",
+    "docx",
+    "ppt",
+    "pptx",
+    "xls",
+    "xlsx",
+    "numbers",
+    "pages",
+    "key",
+    "csv",
+    "txt",
+    "odt",
+    "ods",
+    "odt",
+    "odp",
+    "rtf",
+    "xlt",
+    "psd",
+    "cdr",
+    "eps",
+    "psw",
+    "dot",
+    "tiff"
+  ];
+
+  const webNativeFileExtensions = [
+    "pdf",
+    "apng",
+    "bmp",
+    "gif",
+    "ico",
+    "cur",
+    "jpg",
+    "jpeg",
+    "jfif",
+    "pjpeg",
+    "pjp",
+    "png",
+    "svg",
+    "xml"
+  ];
+
   if (libreOfficeSupportedFileExtensions.includes(fileExtension)) {
-    return responses.CONVERT
+    return responses.CONVERT;
   } else if (webNativeFileExtensions.includes(fileExtension)) {
-    return responses.WEBNATIVE
+    return responses.WEBNATIVE;
   }
-  return responses.UNSUPPORTED
-}
+  return responses.UNSUPPORTED;
+};

--- a/api/test/use-cases/GetDocument.test.js
+++ b/api/test/use-cases/GetDocument.test.js
@@ -124,5 +124,54 @@ describe('GetDocument', function() {
     expect(attachment.url).toBe('http://dummy-url.com/?')
     expect(attachment.extension).toBe('pdf')
   });
+
+  it('does not call converter for unsupported extension', async function() {
+    const documentId = 3;
+    const document = 'document';
+    const edocsGatewaySpy = createEdocsGatewaySpy(document, 'application/x-tar');
+    const s3GatewaySpy = createS3GatewaySpy()
+    const converterSpy = createConverterSpy()
+    const usecase = GetDocument({ edocsGateway: edocsGatewaySpy, s3Gateway: s3GatewaySpy, converter: converterSpy });
+
+    await expect(usecase(documentId, null)).resolves.toEqual(new Error('This document cannot be viewed in your browser, please open in Mosaic on VDI.'))
+  });
+
+  it('does not call converter for web native extension', async function() {
+    const documentId = 4;
+    const document = 'document';
+    const edocsGatewaySpy = createEdocsGatewaySpy(document, 'application/pdf');
+    const s3GatewaySpy = createS3GatewaySpy()
+    const converterSpy = createConverterSpy()
+    const usecase = GetDocument({ edocsGateway: edocsGatewaySpy, s3Gateway: s3GatewaySpy, converter: converterSpy });
+    
+    const attachment = await usecase(documentId, null);
+
+    expect(s3GatewaySpy.get).toHaveBeenCalledTimes(1);
+    expect(s3GatewaySpy.get).toHaveBeenCalledWith(documentId);
+    expect(converterSpy.execute).toHaveBeenCalledTimes(0)
+
+    expect(attachment.doc.toString()).toBe(document);
+    expect(attachment.url).toBe('http://dummy-url.com/?')
+    expect(attachment.extension).toBe('pdf')
+  });
+
+  it('does call converter for ppt extension', async function() {
+    const documentId = 4;
+    const document = 'document';
+    const edocsGatewaySpy = createEdocsGatewaySpy(document, 'application/vnd.ms-powerpoint');
+    const s3GatewaySpy = createS3GatewaySpy()
+    const converterSpy = createConverterSpy()
+    const usecase = GetDocument({ edocsGateway: edocsGatewaySpy, s3Gateway: s3GatewaySpy, converter: converterSpy });
+    
+    const attachment = await usecase(documentId, null);
+
+    expect(s3GatewaySpy.get).toHaveBeenCalledTimes(1);
+    expect(s3GatewaySpy.get).toHaveBeenCalledWith(documentId);
+    expect(converterSpy.execute).toHaveBeenCalledTimes(1)
+    expect(converterSpy.execute).toHaveBeenCalledWith('4.ppt', null)
+    expect(attachment.doc.toString()).toBe(document);
+    expect(attachment.url).toBe('http://dummy-url.com/?')
+    expect(attachment.extension).toBe('pdf')
+  });
 })
  

--- a/api/test/use-cases/GetDocument.test.js
+++ b/api/test/use-cases/GetDocument.test.js
@@ -133,7 +133,7 @@ describe('GetDocument', function() {
     const converterSpy = createConverterSpy()
     const usecase = GetDocument({ edocsGateway: edocsGatewaySpy, s3Gateway: s3GatewaySpy, converter: converterSpy });
 
-    await expect(usecase(documentId, null)).resolves.toEqual(new Error('This document cannot be viewed in your browser, please open in Mosaic on VDI.'))
+    await expect(usecase(documentId, null)).rejects.toEqual(new Error('This document cannot be viewed in your browser, please open in Mosaic on VDI.'))
   });
 
   it('does not call converter for web native extension', async function() {

--- a/api/test/use-cases/SelectFileAction.test.js
+++ b/api/test/use-cases/SelectFileAction.test.js
@@ -1,0 +1,40 @@
+const SelectFileAction = require('../../lib/use-cases/SelectFileAction');
+
+describe('SelectFileAction', function() {
+  it("returns 'unsupported' when file extension isn't supported", async function() {
+    const fileExtension = 'unsupportedFileType' 
+    const result = SelectFileAction(fileExtension);
+
+    expect(result).toBe('unsupported');
+  });
+
+  it("returns 'convert' when file extension can and needs to be converted", async function() {
+    const fileExtension = 'doc' 
+    const result = SelectFileAction(fileExtension);
+    expect(result).toBe('convert');
+  });
+
+  it("returns 'convert' when file extension can and needs to be converted", async function() {
+    const fileExtension = 'docx' 
+    const result = SelectFileAction(fileExtension);
+    expect(result).toBe('convert');
+  });
+
+  it("returns 'convert' when file extension can and needs to be converted", async function() {
+    const fileExtension = 'tiff' 
+    const result = SelectFileAction(fileExtension);
+    expect(result).toBe('convert');
+  });
+
+  it("returns 'web native' when file extension doesn't need to be converted", async function() {
+    const fileExtension = 'pdf' 
+    const result = SelectFileAction(fileExtension);
+    expect(result).toBe('web native');
+  });
+
+  it("returns 'web native' when file extension doesn't need to be converted", async function() {
+    const fileExtension = 'jpeg' 
+    const result = SelectFileAction(fileExtension);
+    expect(result).toBe('web native');
+  });
+})

--- a/serverless.yml
+++ b/serverless.yml
@@ -51,6 +51,7 @@ functions:
       jwtsecret: ${ssm:/common/hackney-jwt-secret}
       allowedGroups: ${ssm:/edocs-api/${self:provider.stage}/allowedGroups}
       redirectUri: ${ssm:/edocs-api/${self:provider.stage}/redirectUri}
+      googleAuthRedirectUri: ${ssm:/common/google-auth-redirect-uri}
   
   edocs-documents-api-authorizer:
     name: edocs-documents-api-authorizer-${self:provider.stage}


### PR DESCRIPTION
Whitelist supported file extensions (files that can be converted or web-native) otherwise show a friendly error message: `Error: This document cannot be viewed in your browser, please open in Mosaic on VDI.`