### PR TITLE
Making sure unsupported doc type error is caught and sent properly

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -75,10 +75,14 @@ app.get('/documents/:documentId', async (req, res) => {
   } catch (err) {
     if (err.statusCode === 400) {
       res.status(err.statusCode)
-      return res.send('Bad Request. :(')
-    } else if (err.statusCode === 404) {
+      return res.send('Bad Request.')
+    } 
+    else if (err.statusCode === 404) {
       res.status(err.statusCode)
       return res.send('Requested document could not be found.')
+    } else if (err.name === 'ConversionError') {
+      res.status(err.statusCode)
+      return res.send(err.message)
     } 
     res.status(500)
     res.send('Internal server error')

--- a/api/lib/use-cases/GetDocument.js
+++ b/api/lib/use-cases/GetDocument.js
@@ -38,8 +38,17 @@ module.exports = function(options) {
 
     const fileAction = selectFileAction(extension);
 
+    class ConversionError extends Error {
+      constructor(message) {
+        super(message);
+        this.name = "ConversionError";
+        this.statusCode = 500
+      }
+    }
+    
     if (fileAction === "unsupported") {
-      throw new Error(
+      console.log(`Document: ${documentId}.${extension} is an unsupported file type, please open in Mosaic on VDI.`)
+      throw new ConversionError(
         "This document cannot be viewed in your browser, please open in Mosaic on VDI."
       );
     }


### PR DESCRIPTION
### Context:
If a user tries to access a document that isn't a supported fiel type, instead of the friendly `This document cannot be viewed in your browser, please open in Mosaic on VDI.` message, they receive `Internal Server Error`.

### Changes:
This PR:
- Adds a new error type, ConversionError, which can be checked for and sent to the user instead of the more generic error.
- Adds logging a message in the console, which might make it easier to debug in the future.